### PR TITLE
fix: 二分查找，左闭右开区间实现中，注释区间范围右侧符号应该是)而不应该是]

### DIFF
--- a/codes/typescript/chapter_searching/binary_search.ts
+++ b/codes/typescript/chapter_searching/binary_search.ts
@@ -29,9 +29,9 @@ const binarySearch1 = function (nums: number[], target: number): number {
     // 循环，当搜索区间为空时跳出（当 i = j 时为空）
     while (i < j) {
         const m = Math.floor(i + (j - i) / 2); // 计算中点索引 m
-        if (nums[m] < target) {        // 此情况说明 target 在区间 [m+1, j] 中
+        if (nums[m] < target) {        // 此情况说明 target 在区间 [m+1, j) 中
             i = m + 1;
-        } else if (nums[m] > target) { // 此情况说明 target 在区间 [i, m] 中
+        } else if (nums[m] > target) { // 此情况说明 target 在区间 [i, m) 中
             j = m;
         } else {                       // 找到目标元素，返回其索引
             return m;

--- a/docs/chapter_searching/binary_search.md
+++ b/docs/chapter_searching/binary_search.md
@@ -230,9 +230,9 @@ $$
         // 循环，当搜索区间为空时跳出（当 i = j 时为空）
         while (i < j) {
             int m = (i + j) / 2;       // 计算中点索引 m
-            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j] 中
+            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1;
-            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m] 中
+            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m) 中
                 j = m;
             else                       // 找到目标元素，返回其索引
                 return m;
@@ -252,9 +252,9 @@ $$
         // 循环，当搜索区间为空时跳出（当 i = j 时为空）
         while (i < j) {
             int m = (i + j) / 2;       // 计算中点索引 m
-            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j] 中
+            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1;
-            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m] 中
+            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m) 中
                 j = m;
             else                       // 找到目标元素，返回其索引
                 return m;
@@ -274,9 +274,9 @@ $$
         # 循环，当搜索区间为空时跳出（当 i = j 时为空）
         while i < j:
             m = (i + j) // 2        # 计算中点索引 m
-            if nums[m] < target:    # 此情况说明 target 在区间 [m+1, j] 中
+            if nums[m] < target:    # 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1
-            elif nums[m] > target:  # 此情况说明 target 在区间 [i, m] 中
+            elif nums[m] > target:  # 此情况说明 target 在区间 [i, m) 中
                 j = m
             else:                   # 找到目标元素，返回其索引
                 return m
@@ -293,9 +293,9 @@ $$
         // 循环，当搜索区间为空时跳出（当 i = j 时为空）
         for i < j {
             m := (i + j) / 2             // 计算中点索引 m
-            if nums[m] < target {        // 此情况说明 target 在区间 [m+1, j] 中
+            if nums[m] < target {        // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1
-            } else if nums[m] > target { // 此情况说明 target 在区间 [i, m] 中
+            } else if nums[m] > target { // 此情况说明 target 在区间 [i, m) 中
                 j = m
             } else {                     // 找到目标元素，返回其索引
                 return m
@@ -316,9 +316,9 @@ $$
         // 循环，当搜索区间为空时跳出（当 i = j 时为空）
         while (i < j) {
             let m = parseInt((i + j) / 2); // 计算中点索引 m ，在 JS 中需使用 parseInt 函数取整
-            if (nums[m] < target)          // 此情况说明 target 在区间 [m+1, j] 中
+            if (nums[m] < target)          // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1;
-            else if (nums[m] > target)     // 此情况说明 target 在区间 [i, m] 中
+            else if (nums[m] > target)     // 此情况说明 target 在区间 [i, m) 中
                 j = m;
             else                           // 找到目标元素，返回其索引
                 return m;
@@ -338,9 +338,9 @@ $$
         // 循环，当搜索区间为空时跳出（当 i = j 时为空）
         while (i < j) {
             const m = Math.floor(i + (j - i) / 2);  // 计算中点索引 m
-            if (nums[m] < target) {                 // 此情况说明 target 在区间 [m+1, j] 中
+            if (nums[m] < target) {                 // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1;
-            } else if (nums[m] > target) {          // 此情况说明 target 在区间 [i, m] 中
+            } else if (nums[m] > target) {          // 此情况说明 target 在区间 [i, m) 中
                 j = m;
             } else {                                // 找到目标元素，返回其索引
                 return m;
@@ -368,9 +368,9 @@ $$
         while (i < j)
         {
             int m = (i + j) / 2;       // 计算中点索引 m
-            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j] 中
+            if (nums[m] < target)      // 此情况说明 target 在区间 [m+1, j) 中
                 i = m + 1;
-            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m] 中
+            else if (nums[m] > target) // 此情况说明 target 在区间 [i, m) 中
                 j = m;
             else                       // 找到目标元素，返回其索引
                 return m;


### PR DESCRIPTION
我觉得需要改一下，这样更好理解