### PR TITLE
[FIX] 修复 queue.md 中基于链表和基于数组实现图例的Tab标签

### DIFF
--- a/docs/chapter_stack_and_queue/queue.md
+++ b/docs/chapter_stack_and_queue/queue.md
@@ -267,7 +267,7 @@ comments: true
 === "LinkedListQueue"
     ![linkedlist_queue](queue.assets/linkedlist_queue.png)
 
-=== "push()"
+=== "offer()"
     ![linkedlist_queue_push](queue.assets/linkedlist_queue_push.png)
 
 === "poll()"
@@ -726,7 +726,7 @@ comments: true
 === "ArrayQueue"
     ![array_queue](queue.assets/array_queue.png)
 
-=== "push()"
+=== "offer()"
     ![array_queue_push](queue.assets/array_queue_push.png)
 
 === "poll()"


### PR DESCRIPTION
统一使用 Java 术语，入队为 offer，避免与前文使用 offer 冲突导致不严谨

If this PR is related to coding or code translation, please fill out the checklist.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).
