### PR TITLE
🦄 refactor(rust/deque):  change LinkedList to VecDeque

### DIFF
--- a/codes/rust/chapter_stack_and_queue/deque.rs
+++ b/codes/rust/chapter_stack_and_queue/deque.rs
@@ -1,7 +1,7 @@
 /*
  * File: deque.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
+ * Author: sjinzh (sjinzh@gmail.com), xBLACKICEx (xBLACKICEx@outlook.com)
  */
 
 include!("../include/include.rs");

--- a/codes/rust/chapter_stack_and_queue/deque.rs
+++ b/codes/rust/chapter_stack_and_queue/deque.rs
@@ -6,12 +6,12 @@
 
 include!("../include/include.rs");
 
-use std::collections::LinkedList;
+use std::collections::VecDeque;
 
 /* Driver Code */
 pub fn main() {
     // 初始化双向队列
-    let mut deque: LinkedList<i32> = LinkedList::new();
+    let mut deque: VecDeque<i32> = VecDeque::new();
     deque.push_back(2);     // 添加至队尾
     deque.push_back(5);
     deque.push_back(4);

--- a/codes/rust/chapter_stack_and_queue/deque.rs
+++ b/codes/rust/chapter_stack_and_queue/deque.rs
@@ -1,7 +1,7 @@
 /*
  * File: deque.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com)
+ * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
  */
 
 include!("../include/include.rs");

--- a/codes/rust/chapter_stack_and_queue/queue.rs
+++ b/codes/rust/chapter_stack_and_queue/queue.rs
@@ -6,12 +6,12 @@
 
 include!("../include/include.rs");
 
-use std::collections::LinkedList;
+use std::collections::VecDeque;
 
 /* Driver Code */
 pub fn main() {
     // 初始化队列
-    let mut queue: LinkedList<i32> = LinkedList::new();
+    let mut queue: VecDeque<i32> = VecDeque::new();
 
     // 元素入队
     queue.push_back(1);

--- a/codes/rust/chapter_stack_and_queue/queue.rs
+++ b/codes/rust/chapter_stack_and_queue/queue.rs
@@ -1,7 +1,7 @@
 /*
  * File: queue.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
+ * Author: sjinzh (sjinzh@gmail.com), xBLACKICEx (xBLACKICEx@outlook.com)
  */
 
 include!("../include/include.rs");

--- a/codes/rust/chapter_stack_and_queue/queue.rs
+++ b/codes/rust/chapter_stack_and_queue/queue.rs
@@ -1,7 +1,7 @@
 /*
  * File: queue.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com)
+ * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
  */
 
 include!("../include/include.rs");

--- a/codes/rust/include/print_util.rs
+++ b/codes/rust/include/print_util.rs
@@ -1,7 +1,7 @@
 /*
  * File: print_util.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com)
+ * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
  */
 
 use std::fmt::Display;

--- a/codes/rust/include/print_util.rs
+++ b/codes/rust/include/print_util.rs
@@ -5,7 +5,7 @@
  */
 
 use std::fmt::Display;
-use std::collections::{HashMap, LinkedList};
+use std::collections::{HashMap, VecDeque};
 
 /* Print an array */
 pub fn print_array<T: Display>(nums: &[T]) {
@@ -27,7 +27,7 @@ pub fn print_hash_map<TKey: Display, TValue: Display>(map: &HashMap<TKey, TValue
 }
 
 /* Print a queue or deque */
-pub fn print_queue<T: Display>(queue: &LinkedList<T>) {
+pub fn print_queue<T: Display>(queue: &VecDeque<T>) {
     print!("[");
     let iter = queue.iter();
     for (i, data) in iter.enumerate() {

--- a/codes/rust/include/print_util.rs
+++ b/codes/rust/include/print_util.rs
@@ -1,7 +1,7 @@
 /*
  * File: print_util.rs
  * Created Time: 2023-02-05
- * Author: sjinzh (sjinzh@gmail.com), (xBLACKICEx@outlook.com)
+ * Author: sjinzh (sjinzh@gmail.com), xBLACKICEx (xBLACKICEx@outlook.com)
  */
 
 use std::fmt::Display;


### PR DESCRIPTION
If this PR is related to coding or code translation, please read the [contribution guideline](https://github.com/krahets/hello-algo/issues/15#issue-1464069591), fill out the checklist, and paste the console outputs to the PR.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).

I think replacing **LinkedList** with **VecDeque** is more in line with the general usage of the Rust language and more in line with the library of the title.