### PR TITLE
feat: add rust codes for bucket sort, counting sort and radix sort

### DIFF
--- a/codes/rust/Cargo.toml
+++ b/codes/rust/Cargo.toml
@@ -124,6 +124,26 @@ path = "chapter_sorting/merge_sort.rs"
 name = "selection_sort"
 path = "chapter_sorting/selection_sort.rs"
 
+# Run Command: cargo run --bin bucket_sort
+[[bin]]
+name = "bucket_sort"
+path = "chapter_sorting/bucket_sort.rs"
+
+# Run Command: cargo run --bin heap_sort
+[[bin]]
+name = "heap_sort"
+path = "chapter_sorting/heap_sort.rs"
+
+# Run Command: cargo run --bin counting_sort
+[[bin]]
+name = "counting_sort"
+path = "chapter_sorting/counting_sort.rs"
+
+# Run Command: cargo run --bin radix_sort
+[[bin]]
+name = "radix_sort"
+path = "chapter_sorting/radix_sort.rs"
+
 # Run Command: cargo run --bin array_stack
 [[bin]]
 name = "array_stack"

--- a/codes/rust/chapter_sorting/bucket_sort.rs
+++ b/codes/rust/chapter_sorting/bucket_sort.rs
@@ -1,0 +1,43 @@
+/*
+ * File: bucket_sort.rs
+ * Created Time: 2023-07-09
+ * Author: night-cruise (2586447362@qq.com)
+ */
+
+include!("../include/include.rs");
+
+/* 桶排序 */
+fn bucket_sort(nums: &mut [f64]) {
+    // 初始化 k = n/2 个桶，预期向每个桶分配 2 个元素
+    let k = nums.len() / 2;
+    let mut buckets = vec![vec![]; k];
+    // 1. 将数组元素分配到各个桶中
+    for &mut num in &mut *nums {
+        // 输入数据范围 [0, 1)，使用 num * k 映射到索引范围 [0, k-1]
+        let i = (num * k as f64) as usize;
+        // 将 num 添加进桶 i
+        buckets[i].push(num);
+    }
+    // 2. 对各个桶执行排序
+    for bucket in &mut buckets {
+        // 使用内置排序函数，也可以替换成其他排序算法
+        bucket.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    }
+    // 3. 遍历桶合并结果
+    let mut i = 0;
+    for bucket in &mut buckets {
+        for &mut num in bucket {
+            nums[i] = num;
+            i += 1;
+        }
+    }
+}
+
+/* Driver Code */
+fn main() {
+    // 设输入数据为浮点数，范围为 [0, 1)
+    let mut nums = [0.49, 0.96, 0.82, 0.09, 0.57, 0.43, 0.91, 0.75, 0.15, 0.37];
+    bucket_sort(&mut nums);
+    print!("桶排序完成后 nums = ");
+    print_util::print_array(&nums);
+}

--- a/codes/rust/chapter_sorting/counting_sort.rs
+++ b/codes/rust/chapter_sorting/counting_sort.rs
@@ -1,0 +1,72 @@
+/*
+ * File: counting_sort.rs
+ * Created Time: 2023-07-09
+ * Author: night-cruise (2586447362@qq.com)
+ */
+
+include!("../include/include.rs");
+
+/* 计数排序 */
+// 简单实现，无法用于排序对象
+fn counting_sort_naive(nums: &mut [i32]) {
+    // 1. 统计数组最大元素 m
+    let m = *nums.into_iter().max().unwrap();
+    // 2. 统计各数字的出现次数
+    // counter[num] 代表 num 的出现次数
+    let mut counter = vec![0; m as usize + 1];
+    for &num in &*nums {
+        counter[num as usize] += 1;
+    }
+    // 3. 遍历 counter ，将各元素填入原数组 nums
+    let mut i = 0;
+    for num in 0..m + 1 {
+        for _ in 0..counter[num as usize] {
+            nums[i] = num;
+            i += 1;
+        }
+    }
+}
+
+/* 计数排序 */
+// 完整实现，可排序对象，并且是稳定排序
+fn counting_sort(nums: &mut [i32]) {
+    // 1. 统计数组最大元素 m
+    let m = *nums.into_iter().max().unwrap();
+    // 2. 统计各数字的出现次数
+    // counter[num] 代表 num 的出现次数
+    let mut counter = vec![0; m as usize + 1];
+    for &num in &*nums {
+        counter[num as usize] += 1;
+    }
+    // 3. 求 counter 的前缀和，将“出现次数”转换为“尾索引”
+    // 即 counter[num]-1 是 num 在 res 中最后一次出现的索引
+    for i in 0..m as usize {
+        counter[i + 1] += counter[i];
+    }
+    // 4. 倒序遍历 nums ，将各元素填入结果数组 res
+    // 初始化数组 res 用于记录结果
+    let n = nums.len();
+    let mut res = vec![0; n];
+    for i in (0..n).rev() {
+        let num = nums[i];
+        res[counter[num as usize] - 1] = num; // 将 num 放置到对应索引处
+        counter[num as usize] -= 1; // 令前缀和自减 1 ，得到下次放置 num 的索引
+    }
+    // 使用结果数组 res 覆盖原数组 nums
+    for i in 0..n {
+        nums[i] = res[i];
+    }
+}
+
+/* Driver Code */
+fn main() {
+    let mut nums = [1, 0, 1, 2, 0, 4, 0, 2, 2, 4];
+    counting_sort_naive(&mut nums);
+    print!("计数排序（无法排序对象）完成后 nums = ");
+    print_util::print_array(&nums);
+
+    let mut nums1 = [1, 0, 1, 2, 0, 4, 0, 2, 2, 4];
+    counting_sort(&mut nums1);
+    print!("\n计数排序完成后 nums1 = ");
+    print_util::print_array(&nums1);
+}

--- a/codes/rust/chapter_sorting/radix_sort.rs
+++ b/codes/rust/chapter_sorting/radix_sort.rs
@@ -1,0 +1,65 @@
+/*
+ * File: radix_sort.rs
+ * Created Time: 2023-07-09
+ * Author: night-cruise (2586447362@qq.com)
+ */
+
+include!("../include/include.rs");
+
+/* 获取元素 num 的第 k 位，其中 exp = 10^(k-1) */
+fn digit(num: i32, exp: i32) -> usize {
+    // 传入 exp 而非 k 可以避免在此重复执行昂贵的次方计算
+    return ((num / exp) % 10) as usize;
+}
+
+/* 计数排序（根据 nums 第 k 位排序） */
+fn counting_sort_digit(nums: &mut [i32], exp: i32) {
+    // 十进制的位范围为 0~9 ，因此需要长度为 10 的桶
+    let mut counter = [0; 10];
+    let n = nums.len();
+    // 统计 0~9 各数字的出现次数
+    for i in 0..n {
+        let d = digit(nums[i], exp); // 获取 nums[i] 第 k 位，记为 d
+        counter[d] += 1; // 统计数字 d 的出现次数
+    }
+    // 求前缀和，将“出现个数”转换为“数组索引”
+    for i in 1..10 {
+        counter[i] += counter[i - 1];
+    }
+    // 倒序遍历，根据桶内统计结果，将各元素填入 res
+    let mut res = vec![0; n];
+    for i in (0..n).rev() {
+        let d = digit(nums[i], exp);
+        let j = counter[d] - 1; // 获取 d 在数组中的索引 j
+        res[j] = nums[i]; // 将当前元素填入索引 j
+        counter[d] -= 1; // 将 d 的数量减 1
+    }
+    // 使用结果覆盖原数组 nums
+    for i in 0..n {
+        nums[i] = res[i];
+    }
+}
+
+/* 基数排序 */
+fn radix_sort(nums: &mut [i32]) {
+    // 获取数组的最大元素，用于判断最大位数
+    let m = *nums.into_iter().max().unwrap();
+    // 按照从低位到高位的顺序遍历
+    let mut exp = 1;
+    while exp <= m {
+        counting_sort_digit(nums, exp);
+        exp *= 10;
+    }
+}
+
+/* Driver Code */
+fn main() {
+    // 基数排序
+    let mut nums = [
+        10546151, 35663510, 42865989, 34862445, 81883077, 88906420, 72429244, 30524779, 82060337,
+        63832996,
+    ];
+    radix_sort(&mut nums);
+    print!("基数排序完成后 nums = ");
+    print_util::print_array(&nums);
+}


### PR DESCRIPTION
If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).

The console outputs of bucket sort:
```
桶排序完成后 nums = [0.09, 0.15, 0.37, 0.43, 0.49, 0.57, 0.75, 0.82, 0.91, 0.96]
```

The console outputs of counting sort:
```
计数排序（无法排序对象）完成后 nums = [0, 0, 0, 1, 1, 2, 2, 2, 4, 4]
计数排序完成后 nums1 = [0, 0, 0, 1, 1, 2, 2, 2, 4, 4]
```

The console outputs of radix sort:
```
基数排序完成后 nums = [10546151, 30524779, 34862445, 35663510, 42865989, 63832996, 72429244, 81883077, 82060337, 88906420]
```