### PR TITLE
Feat: add rust codes for chapter searching

### DIFF
--- a/codes/rust/Cargo.toml
+++ b/codes/rust/Cargo.toml
@@ -114,6 +114,11 @@ path = "chapter_searching/binary_search.rs"
 name = "binary_search_edge"
 path = "chapter_searching/binary_search_edge.rs"
 
+# Run Command: cargo run --bin binary_search_insertion
+[[bin]]
+name = "binary_search_insertion"
+path = "chapter_searching/binary_search_insertion.rs"
+
 # Run Command: cargo run --bin bubble_sort
 [[bin]]
 name = "bubble_sort"

--- a/codes/rust/chapter_searching/binary_search_edge.rs
+++ b/codes/rust/chapter_searching/binary_search_edge.rs
@@ -1,0 +1,51 @@
+/*
+ * File: binary_search_edge.rs
+ * Created Time: 2023-08-30
+ * Author: night-cruise (2586447362@qq.com)
+ */
+
+mod binary_search_insertion;
+
+use binary_search_insertion::binary_search_insertion;
+
+
+/* 二分查找最左一个 target */
+fn binary_search_left_edge(nums: &[i32], target: i32) -> i32 {
+    // 等价于查找 target 的插入点
+    let i = binary_search_insertion(nums, target);
+    // 未找到 target ，返回 -1
+    if i == nums.len() as i32 || nums[i as usize] != target {
+        return -1;
+    }
+    // 找到 target ，返回索引 i
+    i
+}
+
+/* 二分查找最右一个 target */
+fn binary_search_right_edge(nums: &[i32], target: i32) -> i32 {
+    // 转化为查找最左一个 target + 1
+    let i = binary_search_insertion(nums, target + 1);
+    // j 指向最右一个 target ，i 指向首个大于 target 的元素
+    let j = i - 1;
+    // 未找到 target ，返回 -1
+    if j == -1 || nums[j as usize] != target {
+        return -1;
+    }
+    // 找到 target ，返回索引 j
+    j
+}
+
+/* Driver Code */
+fn main() {
+    // 包含重复元素的数组
+    let nums = [1, 3, 6, 6, 6, 6, 6, 10, 12, 15];
+    println!("\n数组 nums = {:?}", nums);
+
+    // 二分查找左边界和右边界
+    for target in [6, 7] {
+        let index = binary_search_left_edge(&nums, target);
+        println!("最左一个元素 {} 的索引为 {}", target, index);
+        let index = binary_search_right_edge(&nums, target);
+        println!("最右一个元素 {} 的索引为 {}", target, index);
+    }
+} 

--- a/codes/rust/chapter_searching/binary_search_insertion.rs
+++ b/codes/rust/chapter_searching/binary_search_insertion.rs
@@ -1,0 +1,62 @@
+/*
+ * File: binary_search_insertion.rs
+ * Created Time: 2023-08-30
+ * Author: night-cruise (2586447362@qq.com)
+ */
+#![allow(unused)]
+
+/* 二分查找插入点（无重复元素） */
+fn binary_search_insertion_simple(nums: &[i32], target: i32) -> i32 {
+    let (mut i, mut j) = (0, nums.len() as i32 - 1);    // 初始化双闭区间 [0, n-1]
+    while i <= j {
+        let m = i + (j - i) / 2;    // 计算中点索引 m
+        if nums[m as usize] < target {
+            i = m + 1;  // target 在区间 [m+1, j] 中
+        } else if nums[m as usize] > target {
+            j = m - 1;  // target 在区间 [i, m-1] 中
+        } else {
+            return m;
+        }
+    }
+    // 未找到 target ，返回插入点 i
+    i
+}
+
+/* 二分查找插入点（存在重复元素） */
+pub fn binary_search_insertion(nums: &[i32], target: i32) -> i32 {
+    let (mut i, mut j) = (0, nums.len() as i32 - 1);    // 初始化双闭区间 [0, n-1]
+    while i <= j {
+        let m = i + (j - i) / 2;    // 计算中点索引 m
+        if nums[m as usize] < target {
+            i = m + 1;  // target 在区间 [m+1, j] 中
+        } else if nums[m as usize] > target {
+            j = m - 1;  // target 在区间 [i, m-1] 中
+        } else {
+            j = m - 1;  // 首个小于 target 的元素在区间 [i, m-1] 中
+        }
+    }
+    // 返回插入点 i
+    i
+}
+
+
+/* Driver Code */
+fn main() {
+    // 无重复元素的数组
+    let nums = [1, 3, 6, 8, 12, 15, 23, 26, 31, 35];
+    println!("\n数组 nums = {:?}", nums);
+    // 二分查找插入点
+    for target in [6, 9] {
+        let index = binary_search_insertion_simple(&nums, target);
+        println!("元素 {} 的插入点的索引为 {}", target, index);
+    }
+
+    // 包含重复元素的数组
+    let nums = [1, 3, 6, 6, 6, 6, 6, 10, 12, 15];
+    println!("\n数组 nums = {:?}", nums);
+    // 二分查找插入点
+    for target in [2, 6, 20] {
+        let index = binary_search_insertion(&nums, target);
+        println!("元素 {} 的插入点的索引为 {}", target, index);
+    }
+}


### PR DESCRIPTION
If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).

The output of `binary_search_insertion.rs`:
```
数组 nums = [1, 3, 6, 8, 12, 15, 23, 26, 31, 35]
元素 6 的插入点的索引为 2
元素 9 的插入点的索引为 4

数组 nums = [1, 3, 6, 6, 6, 6, 6, 10, 12, 15]
元素 2 的插入点的索引为 1
元素 6 的插入点的索引为 2
元素 20 的插入点的索引为 10
```

The output of `binary_search_edge.rs`:
```
数组 nums = [1, 3, 6, 6, 6, 6, 6, 10, 12, 15]
最左一个元素 6 的索引为 2
最右一个元素 6 的索引为 6
最左一个元素 7 的索引为 -1
最右一个元素 7 的索引为 -1
```