### PR TITLE
FixedBug: Update linkedlist_queue.java

### DIFF
--- a/codes/java/chapter_stack_and_queue/linkedlist_queue.java
+++ b/codes/java/chapter_stack_and_queue/linkedlist_queue.java
@@ -50,6 +50,10 @@ class LinkedListQueue {
         // 删除头节点
         front = front.next;
         queSize--;
+        // 如果队列已经空，尾元素设置为null
+        if(queSize == 0) {
+           rear = null; 
+        }
         return num;
     }
 


### PR DESCRIPTION
 pop后，如果队列已经空，尾元素设置为null，这样最后一个节点的资源才能释放掉。 再次push时状态是正确的。

If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [ ] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [ ] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [ ] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).
