### PR TITLE
fix: linkedlist_stack.py 中的peek方法需要判空raise Error 

### DIFF
--- a/codes/python/chapter_stack_and_queue/linkedlist_stack.py
+++ b/codes/python/chapter_stack_and_queue/linkedlist_stack.py
@@ -44,7 +44,7 @@ class LinkedListStack:
         """访问栈顶元素"""
         # 判空处理
         if not self.__peek:
-            return None
+            raise IndexError("栈为空")
         return self.__peek.val
 
     def to_list(self) -> list[int]:


### PR DESCRIPTION
栈空的时候不能再 peek() 。另外由于 pop() 复用了 peek() ，栈空时返回的 None 会传递到 pop() 中的 num ，导致后续的继续执行 
 self.peek.next 报错等后续问题