### PR TITLE
fix a Python variable name in list.md

### DIFF
--- a/docs/chapter_array_and_linkedlist/list.md
+++ b/docs/chapter_array_and_linkedlist/list.md
@@ -17,7 +17,7 @@
     # 无初始值
     list1: list[int] = []
     # 有初始值
-    list: list[int] = [1, 3, 2, 5, 4]
+    list2: list[int] = [1, 3, 2, 5, 4]
     ```
 
 === "C++"
@@ -136,10 +136,10 @@
 
     ```python title="list.py"
     # 访问元素
-    num: int = list[1]  # 访问索引 1 处的元素
+    num: int = list2[1]  # 访问索引 1 处的元素
 
     # 更新元素
-    list[1] = 0    # 将索引 1 处的元素更新为 0
+    list2[1] = 0    # 将索引 1 处的元素更新为 0
     ```
 
 === "C++"
@@ -255,20 +255,20 @@
 
     ```python title="list.py"
     # 清空列表
-    list.clear()
+    list2.clear()
 
     # 尾部添加元素
-    list.append(1)
-    list.append(3)
-    list.append(2)
-    list.append(5)
-    list.append(4)
+    list2.append(1)
+    list2.append(3)
+    list2.append(2)
+    list2.append(5)
+    list2.append(4)
 
     # 中间插入元素
-    list.insert(3, 6)  # 在索引 3 处插入数字 6
+    list2.insert(3, 6)  # 在索引 3 处插入数字 6
 
     # 删除元素
-    list.pop(3)        # 删除索引 3 处的元素
+    list2.pop(3)        # 删除索引 3 处的元素
     ```
 
 === "C++"
@@ -671,7 +671,7 @@
     ```python title="list.py"
     # 拼接两个列表
     list1: list[int] = [6, 8, 7, 10, 9]
-    list += list1  # 将列表 list1 拼接到 list 之后
+    list2 += list1  # 将列表 list1 拼接到 list2 之后
     ```
 
 === "C++"
@@ -771,7 +771,7 @@
 
     ```python title="list.py"
     # 排序列表
-    list.sort()  # 排序后，列表元素从小到大排列
+    list2.sort()  # 排序后，列表元素从小到大排列
     ```
 
 === "C++"


### PR DESCRIPTION
Python 代码中的列表命名为list时，会出现如下错误。
 list:list[int] = [1, 2, 3, 4, 5]
TypeError: list indices must be integers or slices, not type 建议修改为list2

If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).
