### PR TITLE
fix graph_adjacency_matrix.py

### DIFF
--- a/codes/python/chapter_graph/graph_adjacency_matrix.py
+++ b/codes/python/chapter_graph/graph_adjacency_matrix.py
@@ -36,9 +36,11 @@ class GraphAdjMat:
 
     def add_vertex(self, val: int):
         """添加顶点"""
-        n = self.size()
         # 向顶点列表中添加新顶点的值
         self.vertices.append(val)
+        
+        n = self.size()
+        
         # 在邻接矩阵中添加一行
         new_row = [0] * n
         self.adj_mat.append(new_row)


### PR DESCRIPTION
9.2.1   基于邻接矩阵的实现
graph_adjacency_matrix.py中应该先添加顶点，再获取顶点的数量
```python
def add_vertex(self, val: int):
        """添加顶点"""
  
        # 向顶点列表中添加新顶点的值
        self.vertices.append(val)
        n = self.size()
         # 在邻接矩阵中添加一行
        new_row = [0] * n
        self.adj_mat.append(new_row)
        # 在邻接矩阵中添加一列
        for row in self.adj_mat:
            row.append(0)
```
举例来说，如果原来有5个顶点，新添加一个顶点后，矩阵中新的一行和一列应该有6个元素。而在原来的代码实现中仍然只有5个元素
If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [x] I've tested the code and ensured the outputs are the same as the outputs of reference codes.
- [x] I've checked the codes (formatting, comments, indentation, file header, etc) carefully.
- [x] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).
