### PR TITLE
[TypeScript] fix: deep copy old hash table when resizing

### DIFF
--- a/codes/typescript/chapter_hashing/hash_map_chaining.ts
+++ b/codes/typescript/chapter_hashing/hash_map_chaining.ts
@@ -93,7 +93,7 @@ class HashMapChaining {
     /* 扩容哈希表 */
     #extend(): void {
         // 暂存原哈希表
-        const bucketsTmp = this.#buckets;
+        const bucketsTmp = [...this.#buckets];
         // 初始化扩容后的新哈希表
         this.#capacity *= this.#extendRatio;
         this.#buckets = new Array(this.#capacity).fill(null).map((x) => []);


### PR DESCRIPTION
The bucketsTmp variable only holds a reference to the original hash table,  which causes all key-value pairs to be lost after resizing.

Fix this by deep copying the old hash table before resizing,  using Array.prototype.slice to copy array by value.

This ensures bucketsTmp has a full copy of the old hash table, and modifications to the new hash table will not affect it.

If this PR is related to coding or code translation, please fill out the checklist and paste the console outputs to the PR.

- [ ] I've tested the code and ensured the outputs are the same as the outputs of reference code.
- [ ] I've checked the code (formatting, comments, indentation, file header, etc) carefully.
- [ ] The code does not rely on a particular environment or IDE and can be executed on a standard system (Win, macOS, Ubuntu).
