### PR TITLE
translation: Refined the automated translation of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,58 +7,72 @@
 <p align="center">
   <img src="https://readme-typing-svg.demolab.com?font=Noto+Sans+SC&weight=500&duration=3500&pause=2000&color=21C8B8&center=true&vCenter=true&random=false&width=200&lines=Hello%2C+Algo+!" alt="hello-algo-typing-svg" />
   </br>
-  Data Structures and Algorithms: Animated Illutrations and Off-the-Shelf Code
+  Data Structures and Algorithms Crash Course with Animated Illustrations and Off-the-Shelf Code
 </p>
 
 <p align="center">
   <a href="https://www.hello-algo.com/">
-    <img src="https://www.hello-algo.com/index.assets/btn_read_online_dark.png" width="152">
-  </a>
+    <img src="https://www.hello-algo.com/index.assets/btn_read_online_dark.png" width="155"></a>
   <a href="https://github.com/krahets/hello-algo/releases">
-    <img src="https://www.hello-algo.com/index.assets/btn_download_pdf_dark.png" width="152">
-  </a>
+    <img src="https://www.hello-algo.com/index.assets/btn_download_pdf_dark.png" width="155"></a>
 </p>
 
 <p align="center">
-  <img src="https://www.hello-algo.com/index.assets/animation.gif" width="400">
-  <img src="https://www.hello-algo.com/index.assets/running_code.gif" width="400">
+  <img src="https://www.hello-algo.com/index.assets/animation.gif" width="396">
+  <img src="https://www.hello-algo.com/index.assets/running_code.gif" width="396">
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-snow?logo=python&logoColor=3776AB">
+  <img src="https://img.shields.io/badge/C%2B%2B-snow?logo=c%2B%2B&logoColor=00599C">
+  <img src="https://img.shields.io/badge/Java-snow?logo=coffeescript&logoColor=FC4C02">
+  <img src="https://img.shields.io/badge/C%23-snow?logo=csharp&logoColor=512BD4">
+  <img src="https://img.shields.io/badge/Go-snow?logo=go&logoColor=00ADD8">
+  <img src="https://img.shields.io/badge/Swift-snow?logo=swift&logoColor=F05138">
+  <img src="https://img.shields.io/badge/JavaScript-snow?logo=javascript&logoColor=E9CE30">
+  <img src="https://img.shields.io/badge/TypeScript-snow?logo=typescript&logoColor=3178C6">
+  <img src="https://img.shields.io/badge/Dart-snow?logo=dart&logoColor=0175C2">
+  <img src="https://img.shields.io/badge/Rust-snow?logo=rust&logoColor=000000">
+  <img src="https://img.shields.io/badge/C-snow?logo=c&logoColor=A8B9CC">
+  <img src="https://img.shields.io/badge/Zig-snow?logo=zig&logoColor=F7A41D">
+  <img src="https://img.shields.io/badge/Stay%20Tuned-snow">
 </p>
 
 > **Important**
 >
 > We are working on Chinese-to-English translation. For more information please see [#914](https://github.com/krahets/hello-algo/issues/914).
 
-## The Book
+## About
 
-This project aims to create an open-source, free, and beginner-friendly tutorial on data structures and algorithms.
+This project aims to create a free, open-source, and beginner-friendly crash course for data structures and algorithms.
 
-- The book uses animated illustrations to make the content clear, easy to understand, and provides a smooth learning curve, guiding beginners through the knowledge map of data structures and algorithms.
-- The source code can be run with a single click, helping readers improve their programming skills, understand the working principles of algorithms, and the underlying implementation of data structures.
-- We encourage readers to learn together, ask questions, and comment. Replies are usually received within two days.
+- Animated illustrations, easy-to-understand content, and a smooth learning curve help beginners explore the "knowledge map" of data structures and algorithms.
+- Run code with just one click, helping readers improve their programming skills and understand the working principle of algorithms and the underlying implementation of data structures.
+- We encourage readers to help each other. Questions and comments are usually replied to within two days.
 
-If this book is helpful to you, please give it a Star :star: in the top right corner of the page to show your support. Thank you!
+If you find this book helpful, please give it a Star :star: to support us, thank you!
 
-## Praise
+## Recommendations
 
-> “An accessible and easy-to-understand introduction to data structures and algorithms, guiding readers to learn actively and hands-on. Highly recommended for beginners in algorithms.”
+> "An easy-to-understand introductory book on data structures and algorithms, which guides readers to learn by thinking and hands-on, strongly recommended for algorithm beginners."
 >
-> **—— Junhui Deng, Professor of Computer Science at Tsinghua University**
+> **—— Junhui Deng, Professor of Computer Science, Tsinghua University**
 
-> “If I had 'Hello Algorithm' when I was learning data structures and algorithms, it would have been 10 times easier!”
+> "If I had *Hello Algorithm* when I was learning data structures and algorithms, it would have been 10 times easier!"
 >
-> **—— Mu Li, Senior Principal Scientist at Amazon**
+> **—— Mu Li, Senior Principal Scientist, Amazon**
 
 ## Contribution
 
 This open-source book is continuously being updated, and we welcome your participation in this project to provide better learning content for our readers.
 
-- [Content Correction](https://www.hello-algo.com/chapter_appendix/contribution/): Please help us correct or point out issues in the comments section such as grammatical errors, missing content, ambiguities, invalid links, or code bugs.
-- [Code Translation](https://github.com/krahets/hello-algo/issues/15): We look forward to your contributions of code in various programming languages. We currently support Python, Java, C++, Go, JavaScript, and 11 other programming languages.
-- [Whole Book Translation](https://github.com/krahets/hello-algo/tree/en): We invite you to join our Chinese-to-English translation team. Members are mainly from computer-related majors, English majors, and native English speakers.
+- [Content Correction](https://www.hello-algo.com/chapter_appendix/contribution/): Please help us correct or point out mistakes in the comments section such as grammatical errors, missing content, ambiguities, invalid links, or code bugs.
+- [Code Translation](https://github.com/krahets/hello-algo/issues/15): We look forward to your contributions of code in various programming languages. We currently support Python, Java, C++, Go, JavaScript, and 12 other programming languages.
+- [Book Translation](https://github.com/krahets/hello-algo/tree/en): We would love to invite you to join our Chinese-to-English translation team. Members are mainly from computer science related majors, English majors, and native English speakers.
 
-We welcome your valuable suggestions and feedback. If you have any questions, please submit Issues or contact us via WeChat at `krahets-jyd`.
+We welcome your valuable suggestions and feedback. If you have any questions, please submit Issues or reach out via WeChat: `krahets-jyd`.
 
-Thanks to each contributor of this open-source book. It is their selfless dedication that has made this book better. They are:
+We would like to dedicate our thank to all the contributors of this book. It is their selfless dedication that has made this book better. They are:
 
 <p align="left">
     <a href="https://github.com/krahets/hello-algo/graphs/contributors">

--- a/docs-en/index.md
+++ b/docs-en/index.md
@@ -14,7 +14,7 @@ hide:
 
 <h2 align="center">Hello Algo</h2>
 
-<p align="center"> Data Structures and Algorithms: Animated Illutrations and Off-the-Shelf Code </p>
+<p align="center"> Data Structures and Algorithms Crash Course with Animated Illustrations and Off-the-Shelf Code </p>
 
 <p align="center">
   <a href="https://github.com/krahets/hello-algo">

--- a/mkdocs-en.yml
+++ b/mkdocs-en.yml
@@ -4,7 +4,7 @@ INHERIT: mkdocs.yml
 # Project information
 site_name: Hello Algo
 site_url: https://www.hello-algo.com/en/
-site_description: "Data Structures and Algorithms: Animated Illutrations and Off-the-Shelf Code"
+site_description: "Data Structures and Algorithms Crash Course with Animated Illustrations and Off-the-Shelf Code"
 docs_dir: build/docs-en
 site_dir: site/en
 # Repository


### PR DESCRIPTION
### Refined the automated translation for README.md

* Synced README.md with the Chinese version
* Changed a few wording 

A small note: I've removed the line breaks before the `</a>` labels to fix a known render issue:
```
<p align="center">
  <a href="https://www.hello-algo.com/">
    <img src="https://www.hello-algo.com/index.assets/btn_read_online_dark.png" width="155"></a>
  <a href="https://github.com/krahets/hello-algo/releases">
    <img src="https://www.hello-algo.com/index.assets/btn_download_pdf_dark.png" width="155"></a>
</p>
```
The previous format is causing render issue for Chromium-based browsers:

<img width="332" alt="Screenshot 2023-11-09 at 23 52 06" src="https://github.com/krahets/hello-algo/assets/89094576/dd07a804-b068-4f5f-a52b-c077b7ba0dae">

