### PR TITLE
fix: Use .equals() to compare two strings in Java

### DIFF
--- a/codes/java/chapter_tree/array_binary_tree.java
+++ b/codes/java/chapter_tree/array_binary_tree.java
@@ -63,15 +63,15 @@ class ArrayBinaryTree {
         if (val(i) == null)
             return;
         // 前序遍历
-        if (order == "pre")
+        if ("pre".equals(order))
             res.add(val(i));
         dfs(left(i), order, res);
         // 中序遍历
-        if (order == "in")
+        if ("in".equals(order))
             res.add(val(i));
         dfs(right(i), order, res);
         // 后序遍历
-        if (order == "post")
+        if ("post".equals(order))
             res.add(val(i));
     }
 


### PR DESCRIPTION
Java代码中，字符串内容的比较需要使用equals方法，'=='比较的是两个对象的地址是否相等。