### PR TITLE
Update hash_map_chaining.rs . the extend function forgot to initiate the size。

### DIFF
--- a/codes/rust/chapter_hashing/hash_map_chaining.rs
+++ b/codes/rust/chapter_hashing/hash_map_chaining.rs
@@ -68,7 +68,7 @@ impl HashMapChaining {
         // 初始化扩容后的新哈希表
         self.capacity *= self.extend_ratio;
         self.buckets = vec![Vec::new(); self.capacity as usize];
-        self.size = 0;
+        self.size = buckets_tmp.len() as i32;
 
         // 将键值对从原哈希表搬运至新哈希表
         for bucket in buckets_tmp {


### PR DESCRIPTION
the extend function forgot to  initiate the size。

If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [x] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [x] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
