### PR TITLE
fix memory leak in the C code

### DIFF
--- a/codes/c/chapter_hashing/hash_map_open_addressing.c
+++ b/codes/c/chapter_hashing/hash_map_open_addressing.c
@@ -49,6 +49,9 @@ void delHashMapOpenAddressing(HashMapOpenAddressing *hashMap) {
             free(pair);
         }
     }
+    free(hashMap->buckets);
+    free(hashMap->TOMBSTONE);
+    free(hashMap);
 }
 
 /* 哈希函数 */

--- a/codes/c/chapter_stack_and_queue/linkedlist_deque.c
+++ b/codes/c/chapter_stack_and_queue/linkedlist_deque.c
@@ -122,8 +122,8 @@ int pop(LinkedListDeque *deque, bool isFront) {
         if (fNext) {
             fNext->prev = NULL;
             deque->front->next = NULL;
-            delDoublyListNode(deque->front);
         }
+        delDoublyListNode(deque->front);
         deque->front = fNext; // 更新头节点
     }
     // 队尾出队操作
@@ -133,8 +133,8 @@ int pop(LinkedListDeque *deque, bool isFront) {
         if (rPrev) {
             rPrev->next = NULL;
             deque->rear->prev = NULL;
-            delDoublyListNode(deque->rear);
         }
+        delDoublyListNode(deque->rear);
         deque->rear = rPrev; // 更新尾节点
     }
     deque->queSize--; // 更新队列长度


### PR DESCRIPTION
Compared to the C++ version, I think this C version of 'pop' cannot free the popped-out node correctly when it's the only one remains in the queue. This PR fix this and make it consistent with the C++ version.
