### PR TITLE
fix(Rust): no need to clone in hash put fn

### DIFF
--- a/codes/rust/chapter_hashing/hash_map_chaining.rs
+++ b/codes/rust/chapter_hashing/hash_map_chaining.rs
@@ -102,7 +102,6 @@ impl HashMapChaining {
         // 遍历桶，若遇到指定 key ，则更新对应 val 并返回
         for pair in bucket {
             if pair.key == key {
-                // replace value
                 pair.val = val;
                 return;
             }

--- a/codes/rust/chapter_hashing/hash_map_chaining.rs
+++ b/codes/rust/chapter_hashing/hash_map_chaining.rs
@@ -102,17 +102,15 @@ impl HashMapChaining {
         // 遍历桶，若遇到指定 key ，则更新对应 val 并返回
         for pair in bucket {
             if pair.key == key {
-                pair.val = val.clone();
+                // replace value
+                pair.val = val;
                 return;
             }
         }
         let bucket = &mut self.buckets[index];
 
         // 若无该 key ，则将键值对添加至尾部
-        let pair = Pair {
-            key,
-            val: val.clone(),
-        };
+        let pair = Pair { key, val };
         bucket.push(pair);
         self.size += 1;
     }

--- a/codes/rust/chapter_tree/binary_tree_bfs.rs
+++ b/codes/rust/chapter_tree/binary_tree_bfs.rs
@@ -14,7 +14,7 @@ use tree_node::{vec_to_tree, TreeNode};
 fn level_order(root: &Rc<RefCell<TreeNode>>) -> Vec<i32> {
     // 初始化队列，加入根节点
     let mut que = VecDeque::new();
-    que.push_back(Rc::clone(&root));
+    que.push_back(root.clone());
     // 初始化一个列表，用于保存遍历序列
     let mut vec = Vec::new();
 
@@ -22,10 +22,10 @@ fn level_order(root: &Rc<RefCell<TreeNode>>) -> Vec<i32> {
         // 队列出队
         vec.push(node.borrow().val); // 保存节点值
         if let Some(left) = node.borrow().left.as_ref() {
-            que.push_back(Rc::clone(left)); // 左子节点入队
+            que.push_back(left.clone()); // 左子节点入队
         }
         if let Some(right) = node.borrow().right.as_ref() {
-            que.push_back(Rc::clone(right)); // 右子节点入队
+            que.push_back(right.clone()); // 右子节点入队
         };
     }
     vec

--- a/codes/rust/chapter_tree/binary_tree_dfs.rs
+++ b/codes/rust/chapter_tree/binary_tree_dfs.rs
@@ -17,8 +17,8 @@ fn pre_order(root: Option<&Rc<RefCell<TreeNode>>>) -> Vec<i32> {
     if let Some(node) = root {
         // 访问优先级：根节点 -> 左子树 -> 右子树
         result.push(node.borrow().val);
-        result.append(&mut pre_order(node.borrow().left.as_ref()));
-        result.append(&mut pre_order(node.borrow().right.as_ref()));
+        result.extend(pre_order(node.borrow().left.as_ref()));
+        result.extend(pre_order(node.borrow().right.as_ref()));
     }
     result
 }
@@ -29,9 +29,9 @@ fn in_order(root: Option<&Rc<RefCell<TreeNode>>>) -> Vec<i32> {
 
     if let Some(node) = root {
         // 访问优先级：左子树 -> 根节点 -> 右子树
-        result.append(&mut in_order(node.borrow().left.as_ref()));
+        result.extend(in_order(node.borrow().left.as_ref()));
         result.push(node.borrow().val);
-        result.append(&mut in_order(node.borrow().right.as_ref()));
+        result.extend(in_order(node.borrow().right.as_ref()));
     }
     result
 }
@@ -42,8 +42,8 @@ fn post_order(root: Option<&Rc<RefCell<TreeNode>>>) -> Vec<i32> {
 
     if let Some(node) = root {
         // 访问优先级：左子树 -> 右子树 -> 根节点
-        result.append(&mut post_order(node.borrow().left.as_ref()));
-        result.append(&mut post_order(node.borrow().right.as_ref()));
+        result.extend(post_order(node.borrow().left.as_ref()));
+        result.extend(post_order(node.borrow().right.as_ref()));
         result.push(node.borrow().val);
     }
     result

--- a/codes/rust/include/tree_node.rs
+++ b/codes/rust/include/tree_node.rs
@@ -25,7 +25,7 @@ impl TreeNode {
             height: 0,
             parent: None,
             left: None,
-            right: None
+            right: None,
         }))
     }
 }
@@ -34,7 +34,7 @@ impl TreeNode {
 macro_rules! op_vec {
     ( $( $x:expr ),* ) => {
         vec![
-            $( Option::from($x).map(|x| x) ),* 
+            $( Option::from($x).map(|x| x) ),*
         ]
     };
 }
@@ -75,7 +75,7 @@ pub fn vec_to_tree(arr: Vec<Option<i32>>) -> Option<Rc<RefCell<TreeNode>>> {
 fn tree_to_vec_dfs(root: Option<Rc<RefCell<TreeNode>>>, i: usize, res: &mut Vec<Option<i32>>) {
     if root.is_none() {
         return;
-    }    
+    }
     let root = root.unwrap();
     while i >= res.len() {
         res.push(None);

--- a/codes/rust/include/tree_node.rs
+++ b/codes/rust/include/tree_node.rs
@@ -77,7 +77,8 @@ fn tree_to_vec_dfs(root: Option<Rc<RefCell<TreeNode>>>, i: usize, res: &mut Vec<
         return;
     }
     let root = root.unwrap();
-    while i >= res.len() {
+    // i + 1 is the minimum valid size to access index i
+    while res.len() < i + 1 {
         res.push(None);
     }
     res[i] = Some(root.borrow().val);


### PR DESCRIPTION
in this fn:
`    fn put(&mut self, key: i32, val: String) `

as you can see from the method signature val is owned by this method, so there's no need to clone to put in hash bucket.

and fmt some code to drop unseen space, but it shows in my editor:

<img width="897" alt="图片" src="https://github.com/krahets/hello-algo/assets/1034762/37b7a0c2-da11-47f8-a019-fec506314490">
