### PR TITLE
fix(Rust): Update my_heap.rs

### DIFF
--- a/codes/rust/chapter_heap/my_heap.rs
+++ b/codes/rust/chapter_heap/my_heap.rs
@@ -96,7 +96,7 @@ impl MaxHeap {
         // 交换根节点与最右叶节点（交换首元素与尾元素）
         self.swap(0, self.size() - 1);
         // 删除节点
-        let val = self.max_heap.remove(self.size() - 1);
+        let val = self.max_heap.pop().unwrap();
         // 从顶至底堆化
         self.sift_down(0);
         // 返回堆顶元素


### PR DESCRIPTION
First I find here using pop is better than remove, but I'm hesitate to create a PR for this(in case some inconsistent) until I found cpp is using pop_back() too. so here I am :)