### PR TITLE
Update array_deque.cpp函数index()

### DIFF
--- a/codes/cpp/chapter_stack_and_queue/array_deque.cpp
+++ b/codes/cpp/chapter_stack_and_queue/array_deque.cpp
@@ -40,7 +40,7 @@ class ArrayDeque {
         // 通过取余操作实现数组首尾相连
         // 当 i 越过数组尾部后，回到头部
         // 当 i 越过数组头部后，回到尾部
-        return (i + capacity()) % capacity();
+        return (i % capacity() + capacity()) % capacity();
     }
 
     /* 队首入队 */


### PR DESCRIPTION
将43行的return (i + capacity()) % capacity();改为return (i % capacity() + capacity()) % capacity()； 原因：原来的表达式“(i + capacity()) % capacity();”如果i是负数的话，需要保证capacity() >= -i。而更改后的表达式“ (i % capacity() + capacity()) % capacity();” 中的先对i取模相加，最后再取模操作会确保结果是一个非负整数，并且不会超过 capacity() 的值。这是因为取模操作会返回一个在 0 到 capacity() - 1 范围内的数，即使原始的和可能是负数。保证函数index()的传入形参i<-capacity()不会崩溃，且能正确返回 0 到 capacity() - 1 范围内的的索引值。

If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [ ] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [ ] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [ ] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [ ] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [ ] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
