### PR TITLE
给邻接表的图实现添加一个边是否存在的判定

### DIFF
--- a/codes/rust/chapter_graph/graph_adjacency_list.rs
+++ b/codes/rust/chapter_graph/graph_adjacency_list.rs
@@ -42,6 +42,13 @@ impl GraphAdjList {
         {
             panic!("value error");
         }
+
+        // 判断边是否已经存在
+        if self.adj_list[&vet1].contains(&vet2) || self.adj_list[&vet2].contains(&vet1) {
+            println!("边 {}-{} 已经存在，无需重复添加", vet1.val, vet2.val);
+            return;
+        }
+
         // 添加边 vet1 - vet2
         self.adj_list.get_mut(&vet1).unwrap().push(vet2);
         self.adj_list.get_mut(&vet2).unwrap().push(vet1);
@@ -54,6 +61,13 @@ impl GraphAdjList {
         {
             panic!("value error");
         }
+
+        // 判断边是否存在
+        if !self.adj_list[&vet1].contains(&vet2) || !self.adj_list[&vet2].contains(&vet1) {
+            println!("边 {}-{} 不存在，无需删除", vet1.val, vet2.val);
+            return;
+        }
+
         // 删除边 vet1 - vet2
         self.adj_list
             .get_mut(&vet1)


### PR DESCRIPTION
在rust的邻接表实现图的程序中，对于添加边（或删除边）缺少了确认边存在（或不存在）。这会导致如果出现边存在的情况下添加边导致列表中存在重复的边。
![截图 2024-06-29 00-45-26](https://github.com/krahets/hello-algo/assets/87167211/c6c95351-21f7-4e23-8902-0a819a7f5496)
添加一个判定后可避免该结果的产生