### PR TITLE
Rust: remove unnecessary type conversions

### DIFF
--- a/codes/rust/chapter_computational_complexity/time_complexity.rs
+++ b/codes/rust/chapter_computational_complexity/time_complexity.rs
@@ -113,7 +113,7 @@ fn linear_log_recur(n: i32) -> i32 {
         return 1;
     }
     let mut count = linear_log_recur(n / 2) + linear_log_recur(n / 2);
-    for _ in 0..n as i32 {
+    for _ in 0..n {
         count += 1;
     }
     return count;


### PR DESCRIPTION
There is no need to use `as` to convert the type of ignored value.

- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
