### PR TITLE
fix(graph): enhance the judgment of corner case for removeEdge functions

### DIFF
--- a/codes/javascript/chapter_graph/graph_adjacency_list.js
+++ b/codes/javascript/chapter_graph/graph_adjacency_list.js
@@ -46,7 +46,8 @@ class GraphAdjList {
         if (
             !this.adjList.has(vet1) ||
             !this.adjList.has(vet2) ||
-            vet1 === vet2
+            vet1 === vet2 ||
+            this.adjList.get(vet1).indexOf(vet2) === -1
         ) {
             throw new Error('Illegal Argument Exception');
         }

--- a/codes/typescript/chapter_graph/graph_adjacency_list.ts
+++ b/codes/typescript/chapter_graph/graph_adjacency_list.ts
@@ -46,7 +46,8 @@ class GraphAdjList {
         if (
             !this.adjList.has(vet1) ||
             !this.adjList.has(vet2) ||
-            vet1 === vet2
+            vet1 === vet2 ||
+            this.adjList.get(vet1).indexOf(vet2) === -1
         ) {
             throw new Error('Illegal Argument Exception');
         }

--- a/zh-hant/codes/javascript/chapter_graph/graph_adjacency_list.js
+++ b/zh-hant/codes/javascript/chapter_graph/graph_adjacency_list.js
@@ -46,7 +46,8 @@ class GraphAdjList {
         if (
             !this.adjList.has(vet1) ||
             !this.adjList.has(vet2) ||
-            vet1 === vet2
+            vet1 === vet2 ||
+            this.adjList.get(vet1).indexOf(vet2) === -1
         ) {
             throw new Error('Illegal Argument Exception');
         }

--- a/zh-hant/codes/typescript/chapter_graph/graph_adjacency_list.ts
+++ b/zh-hant/codes/typescript/chapter_graph/graph_adjacency_list.ts
@@ -46,7 +46,8 @@ class GraphAdjList {
         if (
             !this.adjList.has(vet1) ||
             !this.adjList.has(vet2) ||
-            vet1 === vet2
+            vet1 === vet2 ||
+            this.adjList.get(vet1).indexOf(vet2) === -1
         ) {
             throw new Error('Illegal Argument Exception');
         }


### PR DESCRIPTION
9.2.2 基于邻接表的实现中 JS 和 TS 代码片段 `removeEdge` 函数如果传入的两个顶点不为邻接点，那么在对应邻接表 `adjList` 中查找不到对应的顶点，返回 -1，继续执行则会删除顶点的邻接顶点表最后一项，即 `splice(-1, 1)`。

通过添加边界条件判断两顶点是否为邻接点修复此问题。

If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [ ] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [ ] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.

相关代码控制台输出：
```js
初始化后，图为
邻接表 =
1: 3,5
3: 1,2
2: 3,5,4
5: 2,1,4
4: 2,5

添加边 1-2 后，图为
邻接表 =
1: 3,5,2
3: 1,2
2: 3,5,4,1
5: 2,1,4
4: 2,5

删除边 1-3 后，图为
邻接表 =
1: 5,2
3: 2
2: 3,5,4,1
5: 2,1,4
4: 2,5

添加顶点 6 后，图为
邻接表 =
1: 5,2
3: 2
2: 3,5,4,1
5: 2,1,4
4: 2,5
6:

删除顶点 3 后，图为
邻接表 =
1: 5,2
2: 5,4,1
5: 2,1,4
4: 2,5
6:
```