### PR TITLE
fix: right-left and left-right inversion for the English version of AVL Tree

### DIFF
--- a/en/docs/chapter_tree/avl_tree.md
+++ b/en/docs/chapter_tree/avl_tree.md
@@ -291,15 +291,15 @@ It can be observed that **the right and left rotation operations are logically s
 
 ### Right-left rotation
 
-For the unbalanced node 3 shown in the figure below, using either left or right rotation alone cannot restore balance to the subtree. In this case, a "left rotation" needs to be performed on `child` first, followed by a "right rotation" on `node`.
-
-![Right-left rotation](avl_tree.assets/avltree_left_right_rotate.png)
-
-### Left-right rotation
-
 As shown in the figure below, for the mirror case of the above unbalanced binary tree, a "right rotation" needs to be performed on `child` first, followed by a "left rotation" on `node`.
 
 ![Left-right rotation](avl_tree.assets/avltree_right_left_rotate.png)
+
+### Left-right rotation
+
+For the unbalanced node 3 shown in the figure below, using either left or right rotation alone cannot restore balance to the subtree. In this case, a "left rotation" needs to be performed on `child` first, followed by a "right rotation" on `node`.
+
+![Right-left rotation](avl_tree.assets/avltree_left_right_rotate.png)
 
 ### Choice of rotation
 

--- a/en/docs/chapter_tree/avl_tree.md
+++ b/en/docs/chapter_tree/avl_tree.md
@@ -293,13 +293,13 @@ It can be observed that **the right and left rotation operations are logically s
 
 For the unbalanced node 3 shown in the figure below, using either left or right rotation alone cannot restore balance to the subtree. In this case, a "left rotation" needs to be performed on `child` first, followed by a "right rotation" on `node`.
 
-![Right-left rotation](avl_tree.assets/avltree_left_right_rotate.png)
+![Left-right rotation](avl_tree.assets/avltree_left_right_rotate.png)
 
 ### Right-left rotation
 
 As shown in the figure below, for the mirror case of the above unbalanced binary tree, a "right rotation" needs to be performed on `child` first, followed by a "left rotation" on `node`.
 
-![Left-right rotation](avl_tree.assets/avltree_right_left_rotate.png)
+![Right-left rotation](avl_tree.assets/avltree_right_left_rotate.png)
 
 ### Choice of rotation
 

--- a/en/docs/chapter_tree/avl_tree.md
+++ b/en/docs/chapter_tree/avl_tree.md
@@ -289,17 +289,17 @@ It can be observed that **the right and left rotation operations are logically s
 [file]{avl_tree}-[class]{avl_tree}-[func]{left_rotate}
 ```
 
-### Right-left rotation
-
-As shown in the figure below, for the mirror case of the above unbalanced binary tree, a "right rotation" needs to be performed on `child` first, followed by a "left rotation" on `node`.
-
-![Left-right rotation](avl_tree.assets/avltree_right_left_rotate.png)
-
 ### Left-right rotation
 
 For the unbalanced node 3 shown in the figure below, using either left or right rotation alone cannot restore balance to the subtree. In this case, a "left rotation" needs to be performed on `child` first, followed by a "right rotation" on `node`.
 
 ![Right-left rotation](avl_tree.assets/avltree_left_right_rotate.png)
+
+### Right-left rotation
+
+As shown in the figure below, for the mirror case of the above unbalanced binary tree, a "right rotation" needs to be performed on `child` first, followed by a "left rotation" on `node`.
+
+![Left-right rotation](avl_tree.assets/avltree_right_left_rotate.png)
 
 ### Choice of rotation
 


### PR DESCRIPTION
Fix translation mistake of "先左旋後右旋" from "Right-left" to "Left-right" and "先右旋後左旋" from "Left-right" to "Right-left" on the AVL tree page.