### PR TITLE
Fix python code style issue in linked list deque

### DIFF
--- a/codes/python/chapter_stack_and_queue/linkedlist_deque.py
+++ b/codes/python/chapter_stack_and_queue/linkedlist_deque.py
@@ -69,7 +69,7 @@ class LinkedListDeque:
             val: int = self._front.val  # 暂存头节点值
             # 删除头节点
             fnext: ListNode | None = self._front.next
-            if fnext != None:
+            if fnext is not None:
                 fnext.prev = None
                 self._front.next = None
             self._front = fnext  # 更新头节点
@@ -78,7 +78,7 @@ class LinkedListDeque:
             val: int = self._rear.val  # 暂存尾节点值
             # 删除尾节点
             rprev: ListNode | None = self._rear.prev
-            if rprev != None:
+            if rprev is not None:
                 rprev.next = None
                 self._rear.prev = None
             self._rear = rprev  # 更新尾节点


### PR DESCRIPTION
According to [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations), "Comparisons to singletons like None should always be done with is or is not, never the equality operators."

- [x] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [x] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.
- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
