### PR TITLE
fix: update the implementation of simple_hash.js and .ts

### DIFF
--- a/codes/javascript/chapter_hashing/simple_hash.js
+++ b/codes/javascript/chapter_hashing/simple_hash.js
@@ -31,7 +31,7 @@ function xorHash(key) {
     for (const c of key) {
         hash ^= c.charCodeAt(0);
     }
-    return hash & MODULUS;
+    return hash % MODULUS;
 }
 
 /* 旋转哈希 */

--- a/codes/typescript/chapter_hashing/simple_hash.ts
+++ b/codes/typescript/chapter_hashing/simple_hash.ts
@@ -31,7 +31,7 @@ function xorHash(key: string): number {
     for (const c of key) {
         hash ^= c.charCodeAt(0);
     }
-    return hash & MODULUS;
+    return hash % MODULUS;
 }
 
 /* 旋转哈希 */


### PR DESCRIPTION
The bitwise AND operation does not ensure that the hash value is within an appropriate range. According to the docs, a modulo operation is required here.

Implementations in some other languages ​​have the same issue.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.

<img width="483" alt="image" src="https://github.com/user-attachments/assets/becb7386-0ebd-4238-9d52-cb575d34a8c8" />


