### PR TITLE
Fix formatting of 'list' in documentation

### DIFF
--- a/en/docs/chapter_array_and_linkedlist/list.md
+++ b/en/docs/chapter_array_and_linkedlist/list.md
@@ -1,6 +1,6 @@
 # List
 
-<u>A list</u> is an abstract data structure concept that represents an ordered collection of elements, supporting operations such as element access, modification, insertion, deletion, and traversal, without requiring users to consider capacity limitations. Lists can be implemented based on linked lists or arrays.
+A <u>list</u> is an abstract data structure concept that represents an ordered collection of elements, supporting operations such as element access, modification, insertion, deletion, and traversal, without requiring users to consider capacity limitations. Lists can be implemented based on linked lists or arrays.
 
 - A linked list can naturally be viewed as a list, supporting element insertion, deletion, search, and modification operations, and can flexibly expand dynamically.
 - An array also supports element insertion, deletion, search, and modification, but since its length is immutable, it can only be viewed as a list with length limitations.


### PR DESCRIPTION
*Omitted PR template because this is only a formatting issue, not related to translation nor code*

Underline "list" only instead of "A list" in English translation of unit 4.3 under chapter 4 (Array and Linked Lists).

<!--
If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [ ] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [ ] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [ ] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [ ] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [ ] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
-->