### PR TITLE
fix: fix C++ array initialization in array.md

### DIFF
--- a/docs/chapter_array_and_linkedlist/array.md
+++ b/docs/chapter_array_and_linkedlist/array.md
@@ -23,10 +23,10 @@
     ```cpp title="array.cpp"
     /* 初始化数组 */
     // 存储在栈上
-    int arr[5];
+    int arr[5] = {};
     int nums[5] = { 1, 3, 2, 5, 4 };
     // 存储在堆上（需要手动释放空间）
-    int* arr1 = new int[5];
+    int* arr1 = new int[5] {};
     int* nums1 = new int[5] { 1, 3, 2, 5, 4 };
     ```
 


### PR DESCRIPTION
Eliminate potential UB by initializing the array elements to 0.

Reading the value of an uninitialized array constitutes undefined behavior (UB), so such syntax should be avoided whenever possible. Moreover, initializing the elements to 0 also ensures consistency with the behavior of other programming languages in this example.

<https://godbolt.org/z/eT6Y4E9GW>

If this pull request (PR) pertains to **Chinese-to-English translation**, please confirm that you have read the contribution guidelines and complete the checklist below:

- [ ] This PR represents the translation of a single, complete document, or contains only bug fixes.
- [ ] The translation accurately conveys the original meaning and intent of the Chinese version. If deviations exist, I have provided explanatory comments to clarify the reasons.

If this pull request (PR) is associated with **coding or code transpilation**, please attach the relevant console outputs to the PR and complete the following checklist:

- [x] I have thoroughly reviewed the code, focusing on its formatting, comments, indentation, and file headers.
- [x] I have confirmed that the code execution outputs are consistent with those produced by the reference code (Python or Java).
- [x] The code is designed to be compatible on standard operating systems, including Windows, macOS, and Ubuntu.
