### PR TITLE
Keep edit links on Traditional Chinese exercises

### DIFF
--- a/zh-hant/mkdocs.yml
+++ b/zh-hant/mkdocs.yml
@@ -59,7 +59,6 @@ nav:
     - 2.3 &nbsp; 時間複雜度: chapter_computational_complexity/time_complexity.md
     - 2.4 &nbsp; 空間複雜度: chapter_computational_complexity/space_complexity.md
     - 2.5 &nbsp; 小結: chapter_computational_complexity/summary.md
-    # [hide: [edit]]
     - 2.6 &nbsp; 練習: chapter_computational_complexity/exercises.md
   - 第 3 章 &nbsp; 資料結構:
     # [icon: material/shape-outline]
@@ -69,7 +68,6 @@ nav:
     - 3.3 &nbsp; 數字編碼 *: chapter_data_structure/number_encoding.md
     - 3.4 &nbsp; 字元編碼 *: chapter_data_structure/character_encoding.md
     - 3.5 &nbsp; 小結: chapter_data_structure/summary.md
-    # [hide: [edit]]
     - 3.6 &nbsp; 練習: chapter_data_structure/exercises.md
   - 第 4 章 &nbsp; 陣列與鏈結串列:
     # [icon: material/view-list-outline]
@@ -80,7 +78,6 @@ nav:
     # [status: new]
     - 4.4 &nbsp; 記憶體與快取 *: chapter_array_and_linkedlist/ram_and_cache.md
     - 4.5 &nbsp; 小結: chapter_array_and_linkedlist/summary.md
-    # [hide: [edit]]
     - 4.6 &nbsp; 練習: chapter_array_and_linkedlist/exercises.md
   - 第 5 章 &nbsp; 堆疊與佇列:
     # [icon: material/stack-overflow]
@@ -89,7 +86,6 @@ nav:
     - 5.2 &nbsp; 佇列: chapter_stack_and_queue/queue.md
     - 5.3 &nbsp; 雙向佇列: chapter_stack_and_queue/deque.md
     - 5.4 &nbsp; 小結: chapter_stack_and_queue/summary.md
-    # [hide: [edit]]
     - 5.5 &nbsp; 練習: chapter_stack_and_queue/exercises.md
   - 第 6 章 &nbsp; 雜湊表:
     # [icon: material/table-search]
@@ -98,7 +94,6 @@ nav:
     - 6.2 &nbsp; 雜湊衝突: chapter_hashing/hash_collision.md
     - 6.3 &nbsp; 雜湊演算法: chapter_hashing/hash_algorithm.md
     - 6.4 &nbsp; 小結: chapter_hashing/summary.md
-    # [hide: [edit]]
     - 6.5 &nbsp; 練習: chapter_hashing/exercises.md
   - 第 7 章 &nbsp; 樹:
     # [icon: material/graph-outline]
@@ -109,7 +104,6 @@ nav:
     - 7.4 &nbsp; 二元搜尋樹: chapter_tree/binary_search_tree.md
     - 7.5 &nbsp; AVL *: chapter_tree/avl_tree.md
     - 7.6 &nbsp; 小結: chapter_tree/summary.md
-    # [hide: [edit]]
     - 7.7 &nbsp; 練習: chapter_tree/exercises.md
   - 第 8 章 &nbsp; 堆積:
     # [icon: material/family-tree]
@@ -118,7 +112,6 @@ nav:
     - 8.2 &nbsp; 建堆積操作: chapter_heap/build_heap.md
     - 8.3 &nbsp; Top-k 問題: chapter_heap/top_k.md
     - 8.4 &nbsp; 小結: chapter_heap/summary.md
-    # [hide: [edit]]
     - 8.5 &nbsp; 練習: chapter_heap/exercises.md
   - 第 9 章 &nbsp; 圖:
     # [icon: material/graphql]
@@ -127,7 +120,6 @@ nav:
     - 9.2 &nbsp; 圖基礎操作: chapter_graph/graph_operations.md
     - 9.3 &nbsp; 圖的走訪: chapter_graph/graph_traversal.md
     - 9.4 &nbsp; 小結: chapter_graph/summary.md
-    # [hide: [edit]]
     - 9.5 &nbsp; 練習: chapter_graph/exercises.md
   - 第 10 章 &nbsp; 搜尋:
     # [icon: material/text-search]
@@ -138,7 +130,6 @@ nav:
     - 10.4 &nbsp; 雜湊最佳化策略: chapter_searching/replace_linear_by_hashing.md
     - 10.5 &nbsp; 重識搜尋演算法: chapter_searching/searching_algorithm_revisited.md
     - 10.6 &nbsp; 小結: chapter_searching/summary.md
-    # [hide: [edit]]
     - 10.7 &nbsp; 練習: chapter_searching/exercises.md
   - 第 11 章 &nbsp; 排序:
     # [icon: material/sort-ascending]
@@ -154,7 +145,6 @@ nav:
     - 11.9 &nbsp; 計數排序: chapter_sorting/counting_sort.md
     - 11.10 &nbsp; 基數排序: chapter_sorting/radix_sort.md
     - 11.11 &nbsp; 小結: chapter_sorting/summary.md
-    # [hide: [edit]]
     - 11.12 &nbsp; 練習: chapter_sorting/exercises.md
   - 第 12 章 &nbsp; 分治:
     # [icon: material/set-split]
@@ -164,7 +154,6 @@ nav:
     - 12.3 &nbsp; 構建樹問題: chapter_divide_and_conquer/build_binary_tree_problem.md
     - 12.4 &nbsp; 河內塔問題: chapter_divide_and_conquer/hanota_problem.md
     - 12.5 &nbsp; 小結: chapter_divide_and_conquer/summary.md
-    # [hide: [edit]]
     - 12.6 &nbsp; 練習: chapter_divide_and_conquer/exercises.md
   - 第 13 章 &nbsp; 回溯:
     # [icon: material/map-marker-path]
@@ -174,7 +163,6 @@ nav:
     - 13.3 &nbsp; 子集和問題: chapter_backtracking/subset_sum_problem.md
     - 13.4 &nbsp; N 皇后問題: chapter_backtracking/n_queens_problem.md
     - 13.5 &nbsp; 小結: chapter_backtracking/summary.md
-    # [hide: [edit]]
     - 13.6 &nbsp; 練習: chapter_backtracking/exercises.md
   - 第 14 章 &nbsp; 動態規劃:
     # [icon: material/table-pivot]
@@ -186,7 +174,6 @@ nav:
     - 14.5 &nbsp; 完全背包問題: chapter_dynamic_programming/unbounded_knapsack_problem.md
     - 14.6 &nbsp; 編輯距離問題: chapter_dynamic_programming/edit_distance_problem.md
     - 14.7 &nbsp; 小結: chapter_dynamic_programming/summary.md
-    # [hide: [edit]]
     - 14.8 &nbsp; 練習: chapter_dynamic_programming/exercises.md
   - 第 15 章 &nbsp; 貪婪:
     # [icon: material/head-heart-outline]
@@ -196,7 +183,6 @@ nav:
     - 15.3 &nbsp; 最大容量問題: chapter_greedy/max_capacity_problem.md
     - 15.4 &nbsp; 最大切分乘積問題: chapter_greedy/max_product_cutting_problem.md
     - 15.5 &nbsp; 小結: chapter_greedy/summary.md
-    # [hide: [edit]]
     - 15.6 &nbsp; 練習: chapter_greedy/exercises.md
   - 第 16 章 &nbsp; 附錄:
     # [icon: material/help-circle-outline]


### PR DESCRIPTION
## Summary

- remove the navigation metadata that hid the edit action from Taiwan Traditional Chinese exercise pages
- keep the exercise pages consistent with the rest of the Traditional Chinese edition

## Testing

- rebuilt the Taiwan Traditional Chinese site with Zensical
- verified all 14 exercise pages include the `編輯此頁` action
- verified the generated edit links match the format used by other Traditional Chinese pages
