### PR TITLE
Remove Warp sponsorship and refine endorsement cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,6 @@
 >
 > **—— 李沐，亚马逊资深首席科学家**
 
-## 鸣谢
-
-<p align="left">
-  <a href="https://go.warp.dev/hello-algo">
-    <img src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png" alt="Warp-Github-LG-02" width="500"></a>
-</p>
-
-[Warp is built for coding with multiple AI agents.](https://go.warp.dev/hello-algo)
-
-强烈推荐 Warp 终端，高颜值 + 好用的 AI，体验非常棒！
-
 ## 贡献
 
 本开源书仍在持续更新之中，欢迎您参与本项目，一同为读者提供更优质的学习内容。

--- a/docs/index.html
+++ b/docs/index.html
@@ -147,10 +147,10 @@
 </section>
 
 <!-- Section: endorsements -->
-<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div home-div--black">
+<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content">
         <h3 style="text-align: center; margin: 1em auto;">推荐语</h3>
-        <div class="intro-container" style="margin: 0 auto;">
+        <div class="intro-container endor-container">
             <div class="intro-text endor-text">
                 <p style="margin-bottom: 0;">“一本通俗易懂的数据结构与算法入门书，引导读者手脑并用地学习，强烈推荐算法初学者阅读。”</p>
                 <p style="font-weight: bold;">—— 邓俊辉，清华大学计算机系教授</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -217,22 +217,6 @@
     </div>
 </section>
 
-<!-- Section: special thanks -->
-<section class="home-div home-div--black" data-md-color-primary="grey" data-md-color-scheme="slate">
-    <div class="section-content">
-        <h3 style="text-align: center; margin: 0 0 2em 0;">
-        鸣谢
-        </h3>
-        <a href="https://go.warp.dev/hello-algo">
-            <img src="https://github.com/warpdotdev/brand-assets/raw/main/Github/Sponsor/Warp-Github-LG-02.png"
-                class="device-on-hover intro-image" style="max-width: 30em;" alt="Warp-Github-LG-02" />
-            <div class="text-button" style="margin: 1em auto;">
-                <span>Warp is built for coding with multiple AI agents.</span>
-            </div>
-        </a>
-    </div>
-</section>
-
 <!-- Section: contributors -->
 <section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content" style="max-width: 90vw;">

--- a/en/README.md
+++ b/en/README.md
@@ -69,15 +69,6 @@ If you find this book helpful, please give it a Star :star: to support us, thank
 >
 > **—— Mu Li, Senior Principal Scientist, Amazon**
 
-## Special thanks
-
-<p align="left">
-  <a href="https://go.warp.dev/hello-algo">
-    <img src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png" alt="Warp-Github-LG-02" width="500"></a>
-</p>
-
-[Warp is built for coding with multiple AI agents.](https://go.warp.dev/hello-algo)
-
 ## Contributing
 
 > [!Important]

--- a/en/docs/index.html
+++ b/en/docs/index.html
@@ -135,10 +135,10 @@
 </section>
 
 <!-- Section: endorsements -->
-<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div home-div--black">
+<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content">
         <h3 style="text-align: center; margin: 1em auto;">Endorsements</h3>
-        <div class="intro-container" style="margin: 0 auto;">
+        <div class="intro-container endor-container">
             <div class="intro-text endor-text">
                 <p style="margin-bottom: 0;">“An easy-to-understand introduction to data structures and algorithms that encourages readers to engage both mind and hands. Highly recommended for beginners!”</p>
                 <p style="font-weight: bold;">—— Junhui Deng, Professor, Department of Computer Science and Technology, Tsinghua University</p>

--- a/en/docs/index.html
+++ b/en/docs/index.html
@@ -205,22 +205,6 @@
     </div>
 </section>
 
-<!-- Section: special thanks -->
-<section class="home-div home-div--black" data-md-color-primary="grey" data-md-color-scheme="slate">
-    <div class="section-content">
-        <h3 style="text-align: center; margin: 0 0 2em 0;">
-        Special Thanks
-        </h3>
-        <a href="https://go.warp.dev/hello-algo">
-            <img src="https://github.com/warpdotdev/brand-assets/raw/main/Github/Sponsor/Warp-Github-LG-02.png"
-                class="device-on-hover intro-image" style="max-width: 30em;" alt="Warp-Github-LG-02" />
-            <div class="text-button" style="margin: 1em auto;">
-                <span>Warp is built for coding with multiple AI agents.</span>
-            </div>
-        </a>
-    </div>
-</section>
-
 <!-- Section: contributors -->
 <section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content" style="max-width: 90vw;">

--- a/ja/README.md
+++ b/ja/README.md
@@ -69,17 +69,6 @@
 >
 > **—— 李沐，Amazon シニア・プリンシパル・サイエンティスト**
 
-## 謝辞
-
-<p align="left">
-  <a href="https://go.warp.dev/hello-algo">
-    <img src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png" alt="Warp-Github-LG-02" width="500"></a>
-</p>
-
-[Warp は複数の AI エージェントとともにコーディングするために作られています。](https://go.warp.dev/hello-algo)
-
-Warp ターミナルは、洗練された UI と使いやすい AI を兼ね備えており、非常に優れた体験を提供してくれます。
-
 ## 貢献
 
 本書は現在も継続的に更新されており、読者により良い学習コンテンツを届けるため、プロジェクトへの参加を歓迎しています。

--- a/ja/docs/index.html
+++ b/ja/docs/index.html
@@ -135,10 +135,10 @@
 </section>
 
 <!-- Section: endorsements -->
-<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div home-div--black">
+<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content">
         <h3 style="text-align: center; margin: 1em auto;">推薦文</h3>
-        <div class="intro-container" style="margin: 0 auto;">
+        <div class="intro-container endor-container">
             <div class="intro-text endor-text">
                 <p style="margin-bottom: 0;">「わかりやすいデータ構造とアルゴリズムの入門書で、読者を手と頭の両方を使う学びへと導いてくれます。アルゴリズムを初めて学ぶ人に強くおすすめします。」</p>
                 <p style="font-weight: bold;">—— Junhui Deng、清華大学コンピュータ科学科教授</p>

--- a/ja/docs/index.html
+++ b/ja/docs/index.html
@@ -205,22 +205,6 @@
     </div>
 </section>
 
-<!-- Section: special thanks -->
-<section class="home-div home-div--black" data-md-color-primary="grey" data-md-color-scheme="slate">
-    <div class="section-content">
-        <h3 style="text-align: center; margin: 0 0 2em 0;">
-        謝辞
-        </h3>
-        <a href="https://go.warp.dev/hello-algo">
-            <img src="https://github.com/warpdotdev/brand-assets/raw/main/Github/Sponsor/Warp-Github-LG-02.png"
-                class="device-on-hover intro-image" style="max-width: 30em;" alt="Warp-Github-LG-02" />
-            <div class="text-button" style="margin: 1em auto;">
-                <span>Warp is built for coding with multiple AI agents.</span>
-            </div>
-        </a>
-    </div>
-</section>
-
 <!-- Section: contributors -->
 <section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content" style="max-width: 90vw;">

--- a/overrides/zensical/stylesheets/extra.css
+++ b/overrides/zensical/stylesheets/extra.css
@@ -726,8 +726,20 @@ a:hover .device-on-hover {
   fill: var(--md-primary-bg-color);
 }
 
+.endor-container {
+  align-items: stretch;
+  gap: 20px;
+  margin: 0 auto;
+}
+
 .endor-text {
   width: 50%;
+  margin: 0;
+  padding: 1.25em 2.5em;
+  border-radius: 28px;
+  background-color: #101010;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .intro-quote {
@@ -853,8 +865,14 @@ a:hover .device-on-hover {
   }
 
   .endor-text {
-    width: auto;
-    margin: 0 auto;
+    width: 100%;
+    margin: 0;
+    padding: 1em 2em;
+    border-radius: 20px;
+  }
+
+  .endor-container {
+    gap: 20px;
   }
 
   .intro-image {

--- a/ru/README.md
+++ b/ru/README.md
@@ -68,17 +68,6 @@
 >
 > **—— Mu Li, Senior Principal Scientist, Amazon**
 
-## Благодарности
-
-<p align="left">
-  <a href="https://go.warp.dev/hello-algo">
-    <img src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png" alt="Warp-Github-LG-02" width="500"></a>
-</p>
-
-[Warp создан для программирования с несколькими AI-агентами.](https://go.warp.dev/hello-algo)
-
-Очень рекомендуем терминал Warp: красивый интерфейс, полезные AI-возможности и отличное общее впечатление от работы.
-
 ## Участие
 
 Эта открытая книга продолжает активно развиваться, и мы будем рады вашему участию, чтобы сделать обучение для читателей еще качественнее.

--- a/ru/docs/index.html
+++ b/ru/docs/index.html
@@ -205,22 +205,6 @@
     </div>
 </section>
 
-<!-- Section: special thanks -->
-<section class="home-div home-div--black" data-md-color-primary="grey" data-md-color-scheme="slate">
-    <div class="section-content">
-        <h3 style="text-align: center; margin: 0 0 2em 0;">
-        Благодарности
-        </h3>
-        <a href="https://go.warp.dev/hello-algo">
-            <img src="https://github.com/warpdotdev/brand-assets/raw/main/Github/Sponsor/Warp-Github-LG-02.png"
-                class="device-on-hover intro-image" style="max-width: 30em;" alt="Warp-Github-LG-02" />
-            <div class="text-button" style="margin: 1em auto;">
-                <span>Warp создан для программирования с несколькими AI-агентами.</span>
-            </div>
-        </a>
-    </div>
-</section>
-
 <!-- Section: contributors -->
 <section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content" style="max-width: 90vw;">

--- a/ru/docs/index.html
+++ b/ru/docs/index.html
@@ -135,10 +135,10 @@
 </section>
 
 <!-- Section: endorsements -->
-<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div home-div--black">
+<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content">
         <h3 style="text-align: center; margin: 1em auto;">Рекомендации</h3>
-        <div class="intro-container" style="margin: 0 auto;">
+        <div class="intro-container endor-container">
             <div class="intro-text endor-text">
                 <p style="margin-bottom: 0;">«Понятная вводная книга по структурам данных и алгоритмам, которая ведет читателя через практическое обучение шаг за шагом. Очень рекомендую всем начинающим.»</p>
                 <p style="font-weight: bold;">—— Junhui Deng, профессор факультета компьютерных наук Университета Цинхуа</p>

--- a/zh-hant/README.md
+++ b/zh-hant/README.md
@@ -69,17 +69,6 @@
 >
 > **—— 李沐，亞馬遜資深首席科學家**
 
-## 鳴謝
-
-<p align="left">
-  <a href="https://go.warp.dev/hello-algo">
-    <img src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png" alt="Warp-Github-LG-02" width="500"></a>
-</p>
-
-[Warp is built for coding with multiple AI agents.](https://go.warp.dev/hello-algo)
-
-強烈推薦 Warp 終端，高顏值 + 好用的 AI，體驗非常棒！
-
 ## 貢獻
 
 > [!Important]

--- a/zh-hant/docs/index.html
+++ b/zh-hant/docs/index.html
@@ -217,22 +217,6 @@
     </div>
 </section>
 
-<!-- Section: special thanks -->
-<section class="home-div home-div--black" data-md-color-primary="grey" data-md-color-scheme="slate">
-    <div class="section-content">
-        <h3 style="text-align: center; margin: 0 0 2em 0;">
-        鳴謝
-        </h3>
-        <a href="https://go.warp.dev/hello-algo">
-            <img src="https://github.com/warpdotdev/brand-assets/raw/main/Github/Sponsor/Warp-Github-LG-02.png"
-                class="device-on-hover intro-image" style="max-width: 30em;" alt="Warp-Github-LG-02" />
-                <div class="text-button" style="margin: 1em auto;">
-                <span>Warp is built for coding with multiple AI agents.</span>
-            </div>
-        </a>
-    </div>
-</section>
-
 <!-- Section: contributors -->
 <section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content" style="max-width: 90vw;">

--- a/zh-hant/docs/index.html
+++ b/zh-hant/docs/index.html
@@ -147,10 +147,10 @@
 </section>
 
 <!-- Section: endorsements -->
-<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div home-div--black">
+<section data-md-color-scheme="slate" data-md-color-primary="grey" class="home-div">
     <div class="section-content">
         <h3 style="text-align: center; margin: 1em auto;">推薦語</h3>
-        <div class="intro-container" style="margin: 0 auto;">
+        <div class="intro-container endor-container">
             <div class="intro-text endor-text">
                 <p style="margin-bottom: 0;">“一本通俗易懂的資料結構與演算法入門書，引導讀者手腦並用地學習，強烈推薦演算法初學者閱讀。”</p>
                 <p style="font-weight: bold;">—— 鄧俊輝，清華大學計算機系教授</p>


### PR DESCRIPTION
## Summary

- remove the ended Warp sponsorship from multilingual READMEs and landing pages
- restyle landing-page endorsements as rounded cards

## Validation

- five-language Zensical build
- missing_files=0 and missing_symbols=0 for all languages
- exercise, OpenCC, and review-render checks passed
- locally reviewed and approved for deployment